### PR TITLE
Enhance settings layout and password change handling

### DIFF
--- a/src/app/(dashboard)/settings/change-password/page.tsx
+++ b/src/app/(dashboard)/settings/change-password/page.tsx
@@ -1,10 +1,27 @@
+'use client';
 import { Separator } from '@/components/ui/separator';
+import { useAuthMethod } from '@/hooks/useUserMutations';
+import { AuthMethod } from '@/types/user';
 import { Fingerprint } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import ChangePasswordForm from './change-password-form';
-
+import { toast } from 'sonner';
 export default function SettingsChangePasswordPage() {
+  const authMethod = useAuthMethod();
+  const router = useRouter();
+
+  if (authMethod !== AuthMethod.EMAIL) {
+    toast.error('Email authentication is not supported for password change.');
+    router.push('/settings');
+  }
+
   return (
-    <div className="space-y-6">
+    <div
+      className="space-y-6"
+      style={{
+        display: authMethod !== AuthMethod.EMAIL ? 'none' : 'block',
+      }}
+    >
       <div className="flex items-center gap-2 px-6">
         <div className="bg-muted p-2 rounded-md">
           <Fingerprint className="h-6 w-6 text-muted-foreground" />

--- a/src/app/(dashboard)/settings/components/sidebar-nav.tsx
+++ b/src/app/(dashboard)/settings/components/sidebar-nav.tsx
@@ -18,6 +18,8 @@ interface SidebarNavProps extends React.HTMLAttributes<HTMLElement> {
 export function SidebarNav({ className, items, ...props }: SidebarNavProps) {
   const pathname = usePathname();
 
+  console.log('Disabled or Not', items);
+
   return (
     <nav
       className={cn(
@@ -40,7 +42,7 @@ export function SidebarNav({ className, items, ...props }: SidebarNavProps) {
           onClick={() => {
             if (item.disabled) {
               toast.error(
-                'This feature is not available for your OAuth authentication method.'
+                'Password change is only available for email-based accounts. OAuth users manage their passwords through their provider.'
               );
             }
           }}

--- a/src/app/(dashboard)/settings/layout.tsx
+++ b/src/app/(dashboard)/settings/layout.tsx
@@ -1,7 +1,9 @@
 'use client';
-import { Fingerprint, Settings, UserCheck2Icon, UserPen } from 'lucide-react';
-import { SidebarNav } from './components/sidebar-nav';
 import { useAuthMethod } from '@/hooks/useUserMutations';
+import { AuthMethod } from '@/types/user';
+import { Fingerprint, Settings, UserCheck2Icon, UserPen } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { SidebarNav } from './components/sidebar-nav';
 
 interface SettingsLayoutProps {
   children: React.ReactNode;
@@ -9,6 +11,16 @@ interface SettingsLayoutProps {
 
 export default function SettingsLayout({ children }: SettingsLayoutProps) {
   const authMethod = useAuthMethod();
+  const [disableChangePassword, setDisableChangePassword] = useState(false);
+  console.log('Auth Method', authMethod);
+  useEffect(() => {
+    if (authMethod === AuthMethod.EMAIL) {
+      setDisableChangePassword(false);
+    } else {
+      setDisableChangePassword(true);
+    }
+  }, [authMethod]);
+
   const sidebarNavItems = [
     {
       icon: <Settings className="h-4 w-4" />,
@@ -29,7 +41,7 @@ export default function SettingsLayout({ children }: SettingsLayoutProps) {
       icon: <Fingerprint className="h-4 w-4" />,
       title: 'Change Password',
       href: '/settings/change-password',
-      disabled: authMethod !== 'EMAIL',
+      disabled: disableChangePassword,
     },
   ];
 


### PR DESCRIPTION
Improve the settings layout and change password page to support email authentication. Disable the change password option for non-email users and implement error handling for unsupported authentication methods. Redirect users appropriately when attempting to access the change password feature without email authentication.